### PR TITLE
build-kernel-deb: create version and config files in OUTDIR

### DIFF
--- a/build-kernel-deb.sh
+++ b/build-kernel-deb.sh
@@ -64,6 +64,8 @@ OUTDIR_TMP="${OUTDIR}.tmp"
 install -d -m0755 -- "$OUTDIR_TMP"
 printf '%s\n' "$REV" >"$OUTDIR_TMP/sha1"
 mv -- build~/*.deb "$OUTDIR_TMP/"
+cp -- build~/out/.config $OUTDIR_TMP/config
+cp -- build~/out/include/config/kernel.release $OUTDIR_TMP/version
 
 # build a simple repro in OUTDIR_TMP too
 DIST="squeeze"    # this could be anything


### PR DESCRIPTION
Export UTS_RELEASE string through the new OUTDIR/version file.  This is
to allow teuthology kernel task to verify that the kernel it rebooted
into is the right one reliably and in all cases.

Also, export .config to make debugging regressions a bit easier.

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
