### PR TITLE
build-ceph-rpm.sh: copy "*.patch" from topdir into SOURCES

### DIFF
--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -86,6 +86,7 @@ mkdir -p ${BUILDAREA}/SPECS
 mkdir -p ${BUILDAREA}/RPMS
 mkdir -p ${BUILDAREA}/BUILD
 cp -a ceph-*.tar.bz2 ${BUILDAREA}/SOURCES/.
+cp -a *.patch ${BUILDAREA}/SOURCES || true
 
 # If this is a release candidate, identified by having -rc[0-9] appended to
 # the version number, then fix up the generated rpm spec file by moving the


### PR DESCRIPTION
This allows patches to be applied when building the RPMs; the addition
of the ceph patch to disable /etc/init.d/ceph from autostarting Ceph
daemons leads to the desire for a .patch file, conditionally applied
by the .spec.  See the Ceph sources.

Signed-off-by: Dan Mick dan.mick@inktank.com
