### PR TITLE
Extend autobuilder to support options for clang, -Wall, ThreadSanitizer, and AddressSanitizer

### DIFF
--- a/build-auto.sh
+++ b/build-auto.sh
@@ -14,7 +14,21 @@ if hostname | grep -q -- -clang ; then
     export CC=clang
     export CXX=clang++
 fi
-
+if hostname | grep -q -- -asan; then
+    echo "hostname has -asan, will build with -fsanitize=address"
+    export CFLAGS="-fsanitize=address $CFLAGS"
+    export CXXFLAGS="-fsanitize=address $CXXFLAGS"
+fi
+if hostname | grep -q -- -tsan; then
+    echo "hostname has -tsan, will build with -fsanitize=thread"
+    export CFLAGS="-fsanitize=thread $CFLAGS"
+    export CXXFLAGS="-fsanitize=thread $CXXFLAGS"
+fi
+if hostname | grep -q -- -wall; then
+    echo "hostname has -wall, will build with all possible warnings enabled"
+    export CFLAGS="-Wall -Weverything -Wpedantic $CFLAGS"
+    export CXXFLAGS="-Wall -Weverything -Wpedantic $CXXFLAGS"
+fi
 if hostname | grep -q -- -notcmalloc ; then
     echo "hostname has -notcmalloc, will build --without-tcmalloc --without-cryptopp"
     export CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS --without-tcmalloc"

--- a/build-auto.sh
+++ b/build-auto.sh
@@ -9,6 +9,12 @@ if ! hostname | grep -q ^gitbuilder- ; then
     exit 1
 fi
 
+if hostname | grep -q -- -clang ; then
+    echo "hostname has -clang, will build with CC=clang CXX=clang++"
+    export CC=clang
+    export CXX=clang++
+fi
+
 if hostname | grep -q -- -notcmalloc ; then
     echo "hostname has -notcmalloc, will build --without-tcmalloc --without-cryptopp"
     export CEPH_EXTRA_CONFIGURE_ARGS="$CEPH_EXTRA_CONFIGURE_ARGS --without-tcmalloc"

--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -34,7 +34,7 @@ echo --START-IGNORE-WARNINGS
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
-[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2" CXXFLAGS="-fno-omit-frame-pointer -g -O2" ./configure --with-debug --with-radosgw --with-fuse --with-tcmalloc --with-libatomic-ops --with-gtk2 --with-profiler --enable-cephfs-java || exit 2
+[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2 $CFLAGS" CXXFLAGS="-fno-omit-frame-pointer -g -O2 $CXXFLAGS" ./configure --with-debug --with-radosgw --with-fuse --with-tcmalloc --with-libatomic-ops --with-gtk2 --with-profiler --enable-cephfs-java || exit 2
 
 if [ ! -e Makefile ]; then
     echo "$0: no Makefile, aborting." 1>&2

--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -18,6 +18,16 @@ rm -rf .git/modules/
 /srv/git/bin/git submodule update --init
 git clean -fdx
 
+# If CC is not already defined, use gcc.
+if [ "x$CC" = "x" ]; then
+    export CC=gcc
+fi
+
+# If CXX is not already defined, use g++.
+if [ "x$CXX" = "x" ]; then
+    export CXX=g++
+fi
+
 DIST=`lsb_release -sc`
 
 echo --START-IGNORE-WARNINGS
@@ -42,7 +52,7 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    set -- CC="ccache $CC" CXX="ccache $CXX"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-deb.sh
+++ b/build-ceph-deb.sh
@@ -18,6 +18,15 @@ rm -rf .git/modules/
 /srv/git/bin/git submodule update --init
 git clean -fdx
 
+# If CC is not already defined, use gcc.
+if [ "x$CC" = "x" ]; then
+    export CC=gcc
+fi
+
+# If CXX is not already defined, use g++.
+if [ "x$CXX" = "x" ]; then
+    export CXX=g++
+fi
 
 DISTS=`cat ../../dists`
 
@@ -43,7 +52,7 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    set -- CC="ccache $CC" CXX="ccache $CXX"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-gcov.sh
+++ b/build-ceph-gcov.sh
@@ -19,6 +19,16 @@ rm -rf .git/modules/
 /srv/git/bin/git submodule update --init
 git clean -fdx
 
+# If CC is not already defined, use gcc.
+if [ "x$CC" = "x" ]; then
+    export CC=gcc
+fi
+
+# If CXX is not already defined, use g++.
+if [ "x$CXX" = "x" ]; then
+    export CXX=g++
+fi
+
 echo --START-IGNORE-WARNINGS
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
@@ -41,7 +51,7 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    set -- CC="ccache $CC" CXX="ccache $CXX"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-notcmalloc.sh
+++ b/build-ceph-notcmalloc.sh
@@ -19,6 +19,15 @@ rm -rf .git/modules/
 /srv/git/bin/git submodule update --init
 git clean -fdx
 
+# If CC is not already defined, use gcc.
+if [ "x$CC" = "x" ]; then
+    export CC=gcc
+fi
+
+# If CXX is not already defined, use g++.
+if [ "x$CXX" = "x" ]; then
+    export CXX=g++
+fi
 
 echo --START-IGNORE-WARNINGS
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
@@ -42,7 +51,7 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    set -- CC="ccache $CC" CXX="ccache $CXX"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-notcmalloc.sh
+++ b/build-ceph-notcmalloc.sh
@@ -33,7 +33,7 @@ echo --START-IGNORE-WARNINGS
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
-[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2" CXXFLAGS="-fno-omit-frame-pointer -g" ./configure --with-debug --with-radosgw --with-fuse --without-tcmalloc --with-libatomic-ops --with-gtk2 --with-profiler || exit 2
+[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2 $CFLAGS" CXXFLAGS="-fno-omit-frame-pointer -g $CXXFLAGS" ./configure --with-debug --with-radosgw --with-fuse --without-tcmalloc --with-libatomic-ops --with-gtk2 --with-profiler || exit 2
 
 if [ ! -e Makefile ]; then
     echo "$0: no Makefile, aborting." 1>&2

--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -18,6 +18,16 @@ rm -rf .git/modules/
 /srv/git/bin/git submodule update --init
 git clean -fdx
 
+# If CC is not already defined, use gcc.
+if [ "x$CC" = "x" ]; then
+    export CC=gcc
+fi
+
+# If CXX is not already defined, use g++.
+if [ "x$CXX" = "x" ]; then
+    export CXX=g++
+fi
+
 DISTS=`cat ../../dists`
 TARGET="$(cat ../../rsync-target)"
 TARGET="$(basename $TARGET)"
@@ -67,7 +77,7 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    set -- CC="ccache $CC" CXX="ccache $CXX"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -18,6 +18,16 @@ rm -rf .git/modules/
 /srv/git/bin/git submodule update --init
 git clean -fdx
 
+# If CC is not already defined, use gcc.
+if [ "x$CC" = "x" ]; then
+    export CC=gcc
+fi
+
+# If CXX is not already defined, use g++.
+if [ "x$CXX" = "x" ]; then
+    export CXX=g++
+fi
+
 echo --START-IGNORE-WARNINGS
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
@@ -40,7 +50,7 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    set -- CC="ccache $CC" CXX="ccache $CXX"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -32,7 +32,7 @@ echo --START-IGNORE-WARNINGS
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
-[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2" CXXFLAGS="-fno-omit-frame-pointer -g" ./configure --with-debug --with-radosgw --with-fuse --with-tcmalloc --with-libatomic-ops --with-gtk2 --with-hadoop --with-profiler --enable-cephfs-java --with-librocksdb-static=check || exit 2
+[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2 $CFLAGS" CXXFLAGS="-fno-omit-frame-pointer -g $CXXFLAGS" ./configure --with-debug --with-radosgw --with-fuse --with-tcmalloc --with-libatomic-ops --with-gtk2 --with-hadoop --with-profiler --enable-cephfs-java --with-librocksdb-static=check || exit 2
 
 if [ ! -e Makefile ]; then
     echo "$0: no Makefile, aborting." 1>&2


### PR DESCRIPTION
This is a small series of commits that adds support for:

* Building Ceph with clang/clang++ rather than gcc/g++.
* Building Ceph with "-Wall -Weverything -Wpedantic" defined.
* Building Ceph with AddressSanitizer instrumentation, as supported by Clang >= 3.3 and GCC >= 4.8.
* Building Ceph with ThreadSanitizer instrumentation, as supported by Clang >= 3.2 and GCC >= 4.8.

These can be enabled by building on a host with '-clang', '-wall', '-asan', and/or '-tsan' hostname affixes defined.

(Note that, at least for Clang 3.5, AddressSanitizer and ThreadSanitizer compilation options are mutually-exclusive.)

These changes are untested, though are simple enough that they should work modulo typos.

I may also not have caught all of the different build-cases of interest, as some of the build-scripts hand off to RPM spec files or debian/rules files not stored within the tree.  It's also not clear which of the current build scripts might be obsolete.

Manual testing of these compile-time options shows that:

* Ceph does not currently build successfully with Clang 3.5 with the default compilation options;
* RocksDB as used by Ceph cannot be compiled with Clang 3.5 with the extra warnings enabled, as -Werror is also in effect at that point but it is not completely warning-clean with all of the extra warnings enabled.