### PR TITLE
add gmock to the list of directories to remove

### DIFF
--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -5,6 +5,7 @@ git clean -fdx && git reset --hard
 git submodule foreach 'git clean -fdx && git reset --hard'
 rm -rf ceph-object-corpus
 rm -rf ceph-erasure-code-corpus
+rm -rf src/gmock
 rm -rf src/leveldb
 rm -rf src/libs3
 rm -rf src/mongoose

--- a/build-ceph-deb.sh
+++ b/build-ceph-deb.sh
@@ -5,6 +5,7 @@ git clean -fdx && git reset --hard
 git submodule foreach 'git clean -fdx && git reset --hard'
 rm -rf ceph-object-corpus
 rm -rf ceph-erasure-code-corpus
+rm -rf src/gmock
 rm -rf src/leveldb
 rm -rf src/libs3
 rm -rf src/mongoose

--- a/build-ceph-gcov.sh
+++ b/build-ceph-gcov.sh
@@ -6,6 +6,7 @@ git clean -fdx && git reset --hard
 git submodule foreach 'git clean -fdx && git reset --hard'
 rm -rf ceph-object-corpus
 rm -rf ceph-erasure-code-corpus
+rm -rf src/gmock
 rm -rf src/leveldb
 rm -rf src/libs3
 rm -rf src/mongoose

--- a/build-ceph-notcmalloc.sh
+++ b/build-ceph-notcmalloc.sh
@@ -6,6 +6,7 @@ git clean -fdx && git reset --hard
 git submodule foreach 'git clean -fdx && git reset --hard'
 rm -rf ceph-object-corpus
 rm -rf ceph-erasure-code-corpus
+rm -rf src/gmock
 rm -rf src/leveldb
 rm -rf src/libs3
 rm -rf src/mongoose

--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -5,6 +5,7 @@ git clean -fdx && git reset --hard
 git submodule foreach 'git clean -fdx && git reset --hard'
 rm -rf ceph-object-corpus
 rm -rf ceph-erasure-code-corpus
+rm -rf src/gmock
 rm -rf src/leveldb
 rm -rf src/libs3
 rm -rf src/mongoose

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -5,6 +5,7 @@ git clean -fdx && git reset --hard
 git submodule foreach 'git clean -fdx && git reset --hard'
 rm -rf ceph-object-corpus
 rm -rf ceph-erasure-code-corpus
+rm -rf src/gmock
 rm -rf src/leveldb
 rm -rf src/libs3
 rm -rf src/mongoose


### PR DESCRIPTION
Because gmock is transitioning to a submodule instead of being inlined.

Signed-off-by: Loic Dachary <ldachary@redhat.com>