### PR TITLE
build: use 'git submodule deinit' instead of 'rm -rf'

### DIFF
--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -2,21 +2,11 @@
 set -e
 
 git clean -fdx && git reset --hard
-git submodule foreach 'git clean -fdx && git reset --hard'
-rm -rf ceph-object-corpus
-rm -rf ceph-erasure-code-corpus
-rm -rf src/gmock
-rm -rf src/leveldb
-rm -rf src/libs3
-rm -rf src/mongoose
-rm -rf src/civetweb
-rm -rf src/rocksdb
-rm -rf src/erasure-code/jerasure/gf-complete
-rm -rf src/erasure-code/jerasure/jerasure
+git submodule deinit -f .
 rm -rf .git/modules/
 /srv/git/bin/git submodule sync
 /srv/autobuild-ceph/use-mirror.sh
-/srv/git/bin/git submodule update --init
+/srv/git/bin/git submodule update --init --recursive
 git clean -fdx
 
 DIST=`lsb_release -sc`

--- a/build-ceph-deb.sh
+++ b/build-ceph-deb.sh
@@ -2,21 +2,11 @@
 set -e
 
 git clean -fdx && git reset --hard
-git submodule foreach 'git clean -fdx && git reset --hard'
-rm -rf ceph-object-corpus
-rm -rf ceph-erasure-code-corpus
-rm -rf src/gmock
-rm -rf src/leveldb
-rm -rf src/libs3
-rm -rf src/mongoose
-rm -rf src/civetweb
-rm -rf src/rocksdb
-rm -rf src/erasure-code/jerasure/gf-complete
-rm -rf src/erasure-code/jerasure/jerasure
+git submodule deinit -f .
 rm -rf .git/modules/
 /srv/git/bin/git submodule sync
 /srv/autobuild-ceph/use-mirror.sh
-/srv/git/bin/git submodule update --init
+/srv/git/bin/git submodule update --init --recursive
 git clean -fdx
 
 

--- a/build-ceph-gcov.sh
+++ b/build-ceph-gcov.sh
@@ -3,21 +3,11 @@ set -e
 
 
 git clean -fdx && git reset --hard
-git submodule foreach 'git clean -fdx && git reset --hard'
-rm -rf ceph-object-corpus
-rm -rf ceph-erasure-code-corpus
-rm -rf src/gmock
-rm -rf src/leveldb
-rm -rf src/libs3
-rm -rf src/mongoose
-rm -rf src/civetweb
-rm -rf src/rocksdb
-rm -rf src/erasure-code/jerasure/gf-complete
-rm -rf src/erasure-code/jerasure/jerasure
+git submodule deinit -f .
 rm -rf .git/modules/
 /srv/git/bin/git submodule sync
 /srv/autobuild-ceph/use-mirror.sh
-/srv/git/bin/git submodule update --init
+/srv/git/bin/git submodule update --init --recursive
 git clean -fdx
 
 echo --START-IGNORE-WARNINGS

--- a/build-ceph-notcmalloc.sh
+++ b/build-ceph-notcmalloc.sh
@@ -3,21 +3,11 @@ set -e
 
 
 git clean -fdx && git reset --hard
-git submodule foreach 'git clean -fdx && git reset --hard'
-rm -rf ceph-object-corpus
-rm -rf ceph-erasure-code-corpus
-rm -rf src/gmock
-rm -rf src/leveldb
-rm -rf src/libs3
-rm -rf src/mongoose
-rm -rf src/civetweb
-rm -rf src/rocksdb
-rm -rf src/erasure-code/jerasure/gf-complete
-rm -rf src/erasure-code/jerasure/jerasure
+git submodule deinit -f .
 rm -rf .git/modules/
 /srv/git/bin/git submodule sync
 /srv/autobuild-ceph/use-mirror.sh
-/srv/git/bin/git submodule update --init
+/srv/git/bin/git submodule update --init --recursive
 git clean -fdx
 
 

--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -2,21 +2,11 @@
 set -e
 
 git clean -fdx && git reset --hard
-git submodule foreach 'git clean -fdx && git reset --hard'
-rm -rf ceph-object-corpus
-rm -rf ceph-erasure-code-corpus
-rm -rf src/gmock
-rm -rf src/leveldb
-rm -rf src/libs3
-rm -rf src/mongoose
-rm -rf src/civetweb
-rm -rf src/rocksdb
-rm -rf src/erasure-code/jerasure/gf-complete
-rm -rf src/erasure-code/jerasure/jerasure
+git submodule deinit -f .
 rm -rf .git/modules/
 /srv/git/bin/git submodule sync
 /srv/autobuild-ceph/use-mirror.sh
-/srv/git/bin/git submodule update --init
+/srv/git/bin/git submodule update --init --recursive
 git clean -fdx
 
 DISTS=`cat ../../dists`

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -2,21 +2,11 @@
 set -e
 
 git clean -fdx && git reset --hard
-git submodule foreach 'git clean -fdx && git reset --hard'
-rm -rf ceph-object-corpus
-rm -rf ceph-erasure-code-corpus
-rm -rf src/gmock
-rm -rf src/leveldb
-rm -rf src/libs3
-rm -rf src/mongoose
-rm -rf src/civetweb
-rm -rf src/rocksdb
-rm -rf src/erasure-code/jerasure/gf-complete
-rm -rf src/erasure-code/jerasure/jerasure
+git submodule deinit -f .
 rm -rf .git/modules/
 /srv/git/bin/git submodule sync
 /srv/autobuild-ceph/use-mirror.sh
-/srv/git/bin/git submodule update --init
+/srv/git/bin/git submodule update --init --recursive
 git clean -fdx
 
 echo --START-IGNORE-WARNINGS


### PR DESCRIPTION
Fix submodule handling: deinit submodules instead of
removing them and call update with --recursive, needed
to checkout gtest within gmock.

Signed-off-by: Danny Al-Gaaf danny.al-gaaf@bisect.de
