### PR TITLE
update roles / targets to reflect the current setup

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -5,40 +5,24 @@ import os
 import sys
 
 # old gitbuilders with non-standard hostnames; kill these off with time
-env.roledefs['gitbuilder_ceph'] = [
+env.roledefs['gitbuilder_ceph'] = [ ]
+
+env.roledefs['gitbuilder_ceph_deb_native'] = [
+    'ubuntu@gitbuilder-squeeze-deb-amd64.front.sepia.ceph.com',
+    ]
+
+env.roledefs['gitbuilder_auto'] = [
+    'ubuntu@gitbuilder-ceph-deb-trusty-amd64-blkin.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-deb-precise-amd64-basic.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-deb-precise-amd64-notcmalloc.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-deb-trusty-amd64-basic.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-deb-trusty-amd64-notcmalloc.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-deb-trusty-i386-basic.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-deb-wheezy-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-precise-i386.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-squeeze-amd64.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-squeeze-deb-amd64.front.sepia.ceph.com',
-#broken    'ubuntu@gitbuilder-sles-11sp2-amd64.front.sepia.ceph.com',
-    ]
-env.roledefs['gitbuilder_ceph_deb_native'] = [
-    'ubuntu@gitbuilder-squeeze-deb-amd64.front.sepia.ceph.com',
-    ]
-
-# the fancy ones
-env.roledefs['gitbuilder_auto'] = [
-    'ubuntu@gitbuilder-ceph-deb-trusty-amd64-blkin.front.sepia.ceph.com',
-    'ubuntu@gitbuilder-ceph-deb-precise-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-precise-amd64-gcov.front.sepia.ceph.com',
-    'ubuntu@gitbuilder-ceph-deb-precise-amd64-notcmalloc.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-quantal-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-quantal-amd64-notcmalloc.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-raring-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-saucy-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-saucy-amd64-notcmalloc.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-saucy-armv7l-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-saucy-armv7l-notcmalloc.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-deb-wheezy-amd64-basic.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-tarball-precise-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-tarball-raring-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-tarball-saucy-amd64-basic.front.sepia.ceph.com',
-#    'ubuntu@gitbuilder-ceph-tarball-saucy-i386-basic.front.sepia.ceph.com',
+    'ubuntu@gitbuilder-ceph-tarball-precise-i386-basic.front.sepia.ceph.com',
+    'ubuntu@gitbuilder-ceph-tarball-trusty-amd64-basic.front.sepia.ceph.com',
+    'ubuntu@gitbuilder-ceph-tarball-trusty-i386-basic.front.sepia.ceph.com',
     ]
 
 env.roledefs['gitbuilder_ceph_rpm'] = [
@@ -50,7 +34,6 @@ env.roledefs['gitbuilder_ceph_rpm'] = [
     'ubuntu@gitbuilder-ceph-rpm-rhel7-amd64-basic.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-rpm-rhel7-amd64-notcmalloc.front.sepia.ceph.com',
     ]
-
 
 # kernels
 env.roledefs['gitbuilder_kernel'] = [


### PR DESCRIPTION
The previous update was wrong: a number of targets that were supposed to
create packages were actually set to create tarballs instead. The update
allows to run

       fab fab gitbuilder_auto
       fab fab gitbuilder_ceph_rpm

http://tracker.ceph.com/issues/11052 Fixes: #11052

Signed-off-by: Loic Dachary <loic@dachary.org>