### PR TITLE
build-ceph: run parallel make check when possible

### DIFF
--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -24,7 +24,7 @@ echo --START-IGNORE-WARNINGS
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
 [ -z "$CEPH_EXTRA_CONFIGURE_ARGS" ] && CEPH_EXTRA_CONFIGURE_ARGS=--with-tcmalloc
-[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2" CXXFLAGS="-fno-omit-frame-pointer -g" ./configure --with-debug --with-radosgw --with-fuse --with-libatomic-ops --with-gtk2 --with-hadoop --with-profiler --enable-cephfs-java --with-librocksdb-static=check $CEPH_EXTRA_CONFIGURE_ARGS || exit 2
+[ ! -x configure ] || CFLAGS="-fno-omit-frame-pointer -g -O2" CXXFLAGS="-fno-omit-frame-pointer -g" ./configure --with-debug --with-radosgw --with-libatomic-ops --without-lttng --disable-static $CEPH_EXTRA_CONFIGURE_ARGS || exit 2
 
 if [ ! -e Makefile ]; then
     echo "$0: no Makefile, aborting." 1>&2

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/bash -x
 set -e
 
 git submodule foreach 'git clean -fdx && git reset --hard'
@@ -48,11 +48,35 @@ else
   echo "$0: no ccache found, compiles will be slower." 1>&2
 fi
 
-NCPU=$(( 2 * `grep -c processor /proc/cpuinfo` ))
-ionice -c3 nice -n20 make -j$NCPU "$@" || exit 4
+function can_parallel_make_check() {
+    local commit=$(git rev-parse tags/v0.88^{})
+    git rev-list HEAD | grep --quiet $commit
+}
+
+function maybe_parallel_make_check() {
+    if can_parallel_make_check ; then
+        echo -j$(get_processors)
+    fi
+}
+#
+# Return MIN(8, MAX(1, (number of processors / 2)))
+# Do not try to use more than 8 because it will stress
+# IO too much
+#
+function get_processors() {
+    if test $(nproc) -ge 16 ; then
+        echo 8
+    elif test $(nproc) -ge 2 ; then
+        expr $(nproc) / 2
+    else
+        echo 1
+    fi
+}
+
+make -j$(get_processors) "$@" || exit 4
 
 # run "make check", but give it a time limit in case a test gets stuck
-../maxtime 1800 ionice -c3 nice -n20 make check "$@" || exit 5
+../maxtime 3600 make $(maybe_parallel_make_check) check "$@" || exit 5
 
 REV="$(git rev-parse HEAD)"
 OUTDIR="../out/output/sha1/$REV"


### PR DESCRIPTION
And timeout after 1h instead of 30mn because giant tests take over 20mn
and it's good to have so spare time in case the host is overloaded and
does not respond as fast as it should.

Signed-off-by: Loic Dachary <loic@dachary.org>