### PR TITLE
Use install-deps.sh in build-ceph scripts

### DIFF
--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -22,6 +22,7 @@ git clean -fdx
 DIST=`lsb_release -sc`
 
 echo --START-IGNORE-WARNINGS
+[ ! -x install-deps.sh ] || ./install-deps.sh
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
@@ -34,9 +35,6 @@ if [ ! -e Makefile ]; then
 fi
 
 # Actually build the project
-
-# Install build-time dependencies
-./install-deps.sh
 
 # clear out any $@ potentially passed in
 set --

--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -35,6 +35,9 @@ fi
 
 # Actually build the project
 
+# Install build-time dependencies
+./install-deps.sh
+
 # clear out any $@ potentially passed in
 set --
 

--- a/build-ceph-deb.sh
+++ b/build-ceph-deb.sh
@@ -36,6 +36,9 @@ fi
 
 # Actually build the project
 
+# Install build-time dependencies
+./install-deps.sh
+
 # clear out any $@ potentially passed in
 set --
 

--- a/build-ceph-deb.sh
+++ b/build-ceph-deb.sh
@@ -23,6 +23,7 @@ git clean -fdx
 DISTS=`cat ../../dists`
 
 echo --START-IGNORE-WARNINGS
+[ ! -x install-deps.sh ] || ./install-deps.sh
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
@@ -35,9 +36,6 @@ if [ ! -e Makefile ]; then
 fi
 
 # Actually build the project
-
-# Install build-time dependencies
-./install-deps.sh
 
 # clear out any $@ potentially passed in
 set --

--- a/build-ceph-gcov.sh
+++ b/build-ceph-gcov.sh
@@ -21,6 +21,7 @@ git clean -fdx && git reset --hard
 git clean -fdx
 
 echo --START-IGNORE-WARNINGS
+[ ! -x install-deps.sh ] || ./install-deps.sh
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
@@ -33,9 +34,6 @@ if [ ! -e Makefile ]; then
 fi
 
 # Actually build the project
-
-# Install build-time dependencies
-./install-deps.sh
 
 # clear out any $@ potentially passed in
 set --

--- a/build-ceph-gcov.sh
+++ b/build-ceph-gcov.sh
@@ -34,6 +34,9 @@ fi
 
 # Actually build the project
 
+# Install build-time dependencies
+./install-deps.sh
+
 # clear out any $@ potentially passed in
 set --
 

--- a/build-ceph-notcmalloc.sh
+++ b/build-ceph-notcmalloc.sh
@@ -22,6 +22,7 @@ git clean -fdx
 
 
 echo --START-IGNORE-WARNINGS
+[ ! -x install-deps.sh ] || ./install-deps.sh
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
@@ -34,9 +35,6 @@ if [ ! -e Makefile ]; then
 fi
 
 # Actually build the project
-
-# Install build-time dependencies
-./install-deps.sh
 
 # clear out any $@ potentially passed in
 set --

--- a/build-ceph-notcmalloc.sh
+++ b/build-ceph-notcmalloc.sh
@@ -35,6 +35,9 @@ fi
 
 # Actually build the project
 
+# Install build-time dependencies
+./install-deps.sh
+
 # clear out any $@ potentially passed in
 set --
 

--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -61,6 +61,9 @@ fi
 
 # Actually build the project
 
+# Install build-time dependencies
+./install-deps.sh
+
 # clear out any $@ potentially passed in
 set --
 

--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -47,6 +47,7 @@ then
 fi
 
 echo --START-IGNORE-WARNINGS
+[ ! -x install-deps.sh ] || ./install-deps.sh
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
@@ -60,9 +61,6 @@ if [ ! -e Makefile ]; then
 fi
 
 # Actually build the project
-
-# Install build-time dependencies
-./install-deps.sh
 
 # clear out any $@ potentially passed in
 set --

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -20,6 +20,7 @@ git clean -fdx && git reset --hard
 git clean -fdx
 
 echo --START-IGNORE-WARNINGS
+[ ! -x install-deps.sh ] || ./install-deps.sh
 [ ! -x autogen.sh ] || ./autogen.sh || exit 1
 autoconf || true
 echo --STOP-IGNORE-WARNINGS
@@ -32,9 +33,6 @@ if [ ! -e Makefile ]; then
 fi
 
 # Actually build the project
-
-# Install build-time dependencies
-./install-deps.sh
 
 # clear out any $@ potentially passed in
 set --

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -33,6 +33,9 @@ fi
 
 # Actually build the project
 
+# Install build-time dependencies
+./install-deps.sh
+
 # clear out any $@ potentially passed in
 set --
 


### PR DESCRIPTION
This patch simply runs ./install-deps.sh script to automatically install (build-time) dependencies on platforms that are handled by that script at the beginning of build.
