### PR TITLE
fabfile: always use gitbuilder master

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -145,7 +145,7 @@ def _rh_gitbuilder(flavor, git_repo, extra_remotes={}, extra_packages=[], ignore
     """
     extra_remotes will be fetch but not autobuilt. useful for tags.
     """
-    gitbuilder_commit='304035b8edaf8d64da77a858af1744f13abcd2ad'
+    gitbuilder_commit='master'
     gitbuilder_origin='git://github.com/ceph/gitbuilder.git'
 
     sudo("initctl list|grep -q '^autobuild-ceph\s' && stop autobuild-ceph || /etc/init.d/autobuild-ceph stop || :")
@@ -258,7 +258,7 @@ def _gitbuilder(flavor, git_repo, extra_remotes={}, extra_packages=[], ignore=[]
     """
     extra_remotes will be fetch but not autobuilt. useful for tags.
     """
-    gitbuilder_commit='304035b8edaf8d64da77a858af1744f13abcd2ad'
+    gitbuilder_commit='master'
     gitbuilder_origin='git://github.com/ceph/gitbuilder.git'
 
     # shut down old instance, it exists


### PR DESCRIPTION
Instead of a hardcoded SHA. If a new version of master at
https://github.com/ceph/gitbuilder/commits/master is available, it needs
to be used because it presumably contains a fix. If there is a need to
update the fabfile to take advantage of that fix, it's like having pull
request review twice on a commit. Once when it is reviewed prior to
being merged in gitbuilder and once when it is reviewed to be used in
the fabfile.

Signed-off-by: Loic Dachary <loic@dachary.org>