### PR TITLE
build-ceph-rpm.sh: fix rpmbuild for ceph-release file

### DIFF
--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -217,7 +217,7 @@ gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc
 EOF
 # End of ceph.repo file
 
-rpmbuild -bb --define "_topdir ${BUILDAREA}" --define ${BUILDAREA}/SPECS/ceph-release.spec
+rpmbuild -bb --define "_topdir ${BUILDAREA}" ${BUILDAREA}/SPECS/ceph-release.spec
 
 # Add Dependencies.
 


### PR DESCRIPTION
We don't want that stray --define arg.

Signed-off-by: Sage Weil <sage@redhat.com>