### PR TITLE
tarbal: kill lingering ceph-mon / ceph-osd

### DIFF
--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -86,7 +86,10 @@ function display_failures() {
 
 make -j$(get_processors) "$@" || exit 4
 
-# run "make check", but give it a time limit in case a test gets stuck                                                           
+# run "make check", but give it a time limit in case a test gets stuck
+
+trap "pkill ceph-osd ; pkill ceph-mon" EXIT
+
 if ! ../maxtime 3600 make $(maybe_parallel_make_check) check "$@" ; then
     display_failures .
     exit 5


### PR DESCRIPTION
When a make check fails it is entirely possible that ceph-osd remain,
because they have their own process group. Kill whatever ceph-osd or
ceph-mon are left behind.

We kill ceph-osd / ceph-mon regardless of the success / failure status
of make check because we also want to address the case where a test
pretends to succeed but left daemons behind.

http://tracker.ceph.com/issues/11929 Fixes: #11929

Signed-off-by: Loic Dachary <ldachary@redhat.com>