### PR TITLE
tarbal: kill -9 lingering ceph-mon / ceph-osd

### DIFF
--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -88,7 +88,7 @@ make -j$(get_processors) "$@" || exit 4
 
 # run "make check", but give it a time limit in case a test gets stuck
 
-trap "pkill ceph-osd ; pkill ceph-mon" EXIT
+trap "pkill -9 ceph-osd ; pkill -9 ceph-mon" EXIT
 
 if ! ../maxtime 3600 make $(maybe_parallel_make_check) check "$@" ; then
     display_failures .


### PR DESCRIPTION
be more agressive about killing ceph-mon / ceph-osd as they may be
unresponsive when / if there is a bug.

http://tracker.ceph.com/issues/11929 Fixes: #11929

Signed-off-by: Loic Dachary <ldachary@redhat.com>