### PR TITLE
tarbal: kill -9 ceph-mon / ceph-osd always succeed

### DIFF
--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -88,7 +88,7 @@ make -j$(get_processors) "$@" || exit 4
 
 # run "make check", but give it a time limit in case a test gets stuck
 
-trap "pkill -9 ceph-osd ; pkill -9 ceph-mon" EXIT
+trap "pkill -9 ceph-osd || true ; pkill -9 ceph-mon || true" EXIT
 
 if ! ../maxtime 3600 make $(maybe_parallel_make_check) check "$@" ; then
     display_failures .


### PR DESCRIPTION
The error code of kill -9 ceph-{mon,osd} must be ignored otherwise the
build may return on error if it fails to kill the process just because
all has been cleaned up as it should.

http://tracker.ceph.com/issues/11929 Fixes: #11929

Signed-off-by: Loic Dachary <ldachary@redhat.com>