### PR TITLE
make check times out after 1h30 instead of 1h00

### DIFF
--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -90,7 +90,7 @@ make -j$(get_processors) "$@" || exit 4
 
 trap "pkill -9 ceph-osd ; pkill -9 ceph-mon" EXIT
 
-if ! ../maxtime 3600 make $(maybe_parallel_make_check) check "$@" ; then
+if ! ../maxtime 5400 make $(maybe_parallel_make_check) check "$@" ; then
     display_failures .
     exit 5
 fi


### PR DESCRIPTION
Because of http://tracker.ceph.com/issues/11931 make check on hammer can
take more than one hour without it being a real problem. So we need to
be more generous with the timeout.

Signed-off-by: Loic Dachary <loic@dachary.org>