### PR TITLE
the make check output is in test-suite.log

### DIFF
--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -77,11 +77,12 @@ function get_processors() {
 
 function display_failures() {
     local dir=$1
-    find $dir -name '*.trs' | xargs grep -l FAIL | while read file ; do
-        log=$(dirname $file)/$(basename $file .trs).log
-        echo FAIL: $log
-        cat $log
-    done
+    # can be removed after hammer is retired
+    # or https://github.com/ceph/ceph/pull/4923
+    # is backported to all branches.
+    if ! test -f src/Makefile-env.am || ! grep -q VERBOSE src/Makefile-env.am ; then
+        cat src/test-suite.log
+    fi
 }
 
 make -j$(get_processors) "$@" || exit 4


### PR DESCRIPTION
Searching the .trs files is not compatible with automake-1.11.

See also https://github.com/ceph/ceph/pull/4923 for more context.

Signed-off-by: Loic Dachary <loic@dachary.org>