### PR TITLE
fabfile: filter more precise builders

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -936,16 +936,14 @@ def authorize_ssh_keys():
 def install_filter_branches():
     """install a filter-branches file so old builders will only look at branches before Infernalis
     """
-    filter_branches_path = '/srv/autobuild-ceph/filter-branches'
     # only keep the branches with following keywords in it.
     pre_cxx11_branches = ['hammer',
                           'giant',
                           'firefly',
                           'emperor',
                           'dumpling']
-    sudo('touch {filter}'.format(filter=filter_branches_path))
-    append(filter_branches_path,
-           '\n'.join(pre_cxx11_branches),
+    append('/srv/autobuild-ceph/filter-branches',
+           pre_cxx11_branches,
            use_sudo=True)
 
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -8,6 +8,8 @@ env.roledefs['pre_cxx11'] = [
     'ubuntu@gitbuilder-ceph-deb-precise-amd64-basic.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-deb-precise-amd64-notcmalloc.front.sepia.ceph.com',
     'ubuntu@gitbuilder-ceph-rpm-centos6-5-amd64-basic.front.sepia.ceph.com',
+    'ubuntu@gitbuilder-ceph-tarball-precise-amd64-basic.front.sepia.ceph.com',
+    'ubuntu@gitbuilder-ceph-tarball-precise-i386-basic.front.sepia.ceph.com',
 ]
 
 env.roledefs['gitbuilder_auto'] = [


### PR DESCRIPTION
- filter more precise builders
- avoid duplicated branches in the filter
- simplify the `install_filter_branches()` a little bit. no need to `touch` a file before appending text to it.