### PR TITLE
build-ceph-{deb-native,rpm}.sh: Clean up build directories on failure

### DIFF
--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -54,7 +54,7 @@ fi
 # build the debs
 mkdir -p out~
 rm -rf out~/* || true
-GNUPGHOME="/srv/gnupg" ionice -c3 nice -n20 /srv/ceph-build/build_snapshot_native.sh out~ $DIST
+GNUPGHOME="/srv/gnupg" ionice -c3 nice -n20 /srv/ceph-build/build_snapshot_native.sh out~ $DIST || ( rm -rf out~ && exit 1 )
 
 VER=`cat out~/version`
 echo "VER is $VER"

--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -114,7 +114,7 @@ cp ceph.spec /tmp/ceph.spec
 
 # Build RPMs
 BUILDAREA=`readlink -fn ${BUILDAREA}`   ### rpm wants absolute path
-rpmbuild -ba --define "_topdir ${BUILDAREA}" ceph.spec
+rpmbuild -ba --define "_topdir ${BUILDAREA}" ceph.spec || ( rm -rf ${BUILDAREA} && exit 1 )
 
 # Create and build an RPM for the repository
 


### PR DESCRIPTION
A recent change to a wip branch was leaving a .git file (as in a submodule
pointer to ../../.git/modules/) behind in the out~ or rpmbuild/BUILD
dirs when failing the build, and then because these scripts both have -e,
they immediately exited.

Then, when the next build came around, it tried "git clean", which
recursed into the build dir, found the .git, tried to dereference into
the ultimate dir, and failed.

Harden against this sort of failure by making sure to remove the workdir
immediately, and then fail, when the actual build worker fails.

Signed-off-by: Dan Mick <dan.mick@redhat.com>