### PR TITLE
cleanup virtualenv found in /tmp

### DIFF
--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -18,6 +18,7 @@ git clean -fdx && git reset --hard
 /srv/autobuild-ceph/use-mirror.sh
 /srv/git/bin/git submodule update --init
 git clean -fdx
+rm -fr /tmp/*virtualenv*
 
 echo --START-IGNORE-WARNINGS
 [ ! -x install-deps.sh ] || ./install-deps.sh


### PR DESCRIPTION
Before building we need to get rid of virtualenv created in /tmp as they
may not contain what we expect.

Signed-off-by: Loic Dachary <loic@dachary.org>