### PR TITLE
build: use ccache wrappers rather than setting CC/CXX

### DIFF
--- a/build-ceph-deb-native.sh
+++ b/build-ceph-deb-native.sh
@@ -46,7 +46,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-deb.sh
+++ b/build-ceph-deb.sh
@@ -46,7 +46,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-gcov.sh
+++ b/build-ceph-gcov.sh
@@ -44,7 +44,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-notcmalloc.sh
+++ b/build-ceph-notcmalloc.sh
@@ -45,7 +45,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -72,7 +72,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-ceph.sh
+++ b/build-ceph.sh
@@ -50,7 +50,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-kernel-deb.sh
+++ b/build-kernel-deb.sh
@@ -17,7 +17,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-kernel-raw.sh
+++ b/build-kernel-raw.sh
@@ -19,7 +19,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2

--- a/build-kernel-rpm.sh
+++ b/build-kernel-rpm.sh
@@ -40,7 +40,11 @@ if command -v ccache >/dev/null; then
   if [ ! -e "$CCACHE_DIR" ]; then
     echo "$0: have ccache but cache directory does not exist: $CCACHE_DIR" 1>&2
   else
-    set -- CC='ccache gcc' CXX='ccache g++'
+    CCACHE_PATH="$PATH"
+    for d in /usr/{lib64,lib,lib32,libexec}/ccache{,/bin} ; do
+      test -d "$d" && test -x "$d/g++" && CCACHE_PATH="$d:$PATH" && break
+    done
+    export PATH="$CCACHE_PATH"
   fi
 else
   echo "$0: no ccache found, compiles will be slower." 1>&2


### PR DESCRIPTION
Taken from https://github.com/ceph/ceph/pull/8461 - works around a bug
in distutils (https://bugs.python.org/issue8027)

Signed-off-by: Josh Durgin <jdurgin@redhat.com>