### PR TITLE
build-ceph-rpm.sh: fix the bogus date in changelog

### DIFF
--- a/build-ceph-rpm.sh
+++ b/build-ceph-rpm.sh
@@ -174,11 +174,11 @@ install -pm 644 %{SOURCE0} \
 #/etc/pki/rpm-gpg/*
 
 %changelog
-* Tue Mar 10 2013 Gary Lowell <glowell@inktank.com> - 1-0
+* Sun Mar 10 2013 Gary Lowell <glowell@inktank.com> 1-1
 - Handle both yum and zypper
 - Use URL to ceph git repo for key
 - remove config attribute from repo file
-* Tue Aug 27 2012 Gary Lowell <glowell@inktank.com> - 1-0
+* Mon Aug 27 2012 Gary Lowell <glowell@inktank.com> 1-0
 - Initial Package
 EOF
 #  End of ceph-release.spec file.


### PR DESCRIPTION
rpmbuild complains at seeing the bogus date:
```
warning: bogus date in %changelog: Tue Mar 10 2013 Gary Lowell - 1-0
warning: bogus date in %changelog: Tue Aug 27 2012 Gary Lowell - 1-0
```
so update the weekday to applease it.

also follows
https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/Packagers_Guide/sect-Packagers_Guide-Creating_a_Basic_Spec_File.html
to remove the hyphen before version number.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>